### PR TITLE
v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,28 +34,7 @@ Run a development server at `http://localhost:8080/`. This also will watch & rec
 ## License
 [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)
 
-## Changelog
-
-### 1.1.1
-
-* [ADD] Support for source maps
-* [ADD] ENV flags for proper production builds
-
-### 1.1
-
-* [ADD] html-webpack-plugin
-* [ADD] Adding HMR to the npm run dev-server command
-* [ADD] Template index.html
-* [CHANGE] Add filler content to main.js
-* [CHANGE] Configure webpack to use index.html as a template
-* [CHANGE] Now ignoring dist folder
-* [CHANGE] Updated webpack config with variables, html-webpack-plugin
-* [REMOVE] dist folder no longer needed thanks to html-webpack-plugin
-
-### 1.0
-
-* Initial release.
-
 ## TODO
 - [x] Setup instructions
 - [x] Example of usage
+- [ ] Better production builds

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Watch files in `src/` for changes, recompile on change.
 
 #### `npm run dev`
 
-Run a development server at `http://localhost:8080/webpack-dev-server/`. This also will watch & recompile on file changes.
+Run a development server at `http://localhost:8080/`. This also will watch & recompile on file changes.
 
 ## License
 [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ together into a final JavaScript module.
 ## Requirements
 
 * npm
-* webpack (globally installed)
-* webpack-dev-server (globally installed)
 
 ## Install
 
@@ -29,7 +27,7 @@ Build a production version of `bundle.js` into `dist/`.
 
 Watch files in `src/` for changes, recompile on change.
 
-#### `npm run dev-server`
+#### `npm run dev`
 
 Run a development server at `http://localhost:8080/webpack-dev-server/`. This also will watch & recompile on file changes.
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "webgl-webpack-boilerplate",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "description": "a boilerplate webpack project for getting started with WebGL.",
   "scripts": {
     "build": "NODE_ENV=production webpack --progress --colors",
     "watch": "webpack --progress --colors --watch",
-    "dev-server": "webpack-dev-server --progress --colors --inline --hot"
+    "dev": "webpack-dev-server --progress --colors --inline --hot"
   },
   "author": "Dale Karp <dale@dale.io> (http://dale.io)",
   "license": "CC-BY-4.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "description": "a boilerplate webpack project for getting started with WebGL.",
   "scripts": {
-    "build": "NODE_ENV=production webpack --progress --colors",
+    "build": "NODE_ENV=production webpack -p --progress --colors",
     "watch": "webpack --progress --colors --watch",
-    "dev": "webpack-dev-server --progress --colors --inline --hot"
+    "dev": "webpack-dev-server --content-base dist/ --colors --hot --inline"
   },
   "author": "Dale Karp <dale@dale.io> (http://dale.io)",
   "license": "CC-BY-4.0",
@@ -18,7 +18,7 @@
     "babel-core": "^6.1.19",
     "babel-loader": "^6.1.0",
     "babel-preset-es2015": "^6.1.18",
-    "html-webpack-plugin": "^1.7.0",
+    "html-webpack-plugin": "^2.8.1",
     "webpack": "^1.12.4",
     "webpack-dev-server": "^1.12.1",
     "webpack-glsl-loader": "^1.0.1"

--- a/src/index.html
+++ b/src/index.html
@@ -1,11 +1,11 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <meta http-equiv="Content-type" content="text/html; charset=utf-8"/>
-        <title>{%= o.htmlWebpackPlugin.options.title %}</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title><%= htmlWebpackPlugin.options.title %></title>
     </head>
     <body>
         <canvas id="canvas"></canvas>
-
     </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var ROOT_PATH = path.resolve(__dirname);
@@ -12,40 +13,42 @@ var BUILD_PATH = path.resolve(ROOT_PATH, 'dist');
 var debug = process.env.NODE_ENV !== 'production';
 
 module.exports = {
-    entry: ENTRY_PATH,
-    plugins: [
-        new HtmlWebpackPlugin({
-            title: 'WebGL Project Boilerplate',
-            template: TEMPLATE_PATH,
-            inject: 'body'
-        })
-    ],
-    output: {
-        path: BUILD_PATH,
-        filename: 'bundle.js'
-    },
-    resolve: {
-        root: [JS_PATH, SRC_PATH]
-    },
-    module: {
-        loaders: [
-            {
-                test: /\.js$/,
-                include: JS_PATH,
-                exclude: /(node_modules|bower_components)/,
-                loader: 'babel',
-                query: {
-                    cacheDirectory: true,
-                    presets: ['es2015']
-                }
-            },
-            {
-                test: /\.glsl$/,
-                include: SHADER_PATH,
-                loader: 'webpack-glsl'
-            }
-        ]
-    },
-    debug: debug,
-    devtool: debug ? 'eval-source-map' : 'source-map'
+  entry: ENTRY_PATH,
+  output: {
+    path: BUILD_PATH,
+    filename: 'bundle.js'
+  },
+  plugins: [
+    new HtmlWebpackPlugin({
+      title: 'WebGL Project Boilerplate',
+      template: TEMPLATE_PATH
+    }),
+    new webpack.DefinePlugin({
+      __DEV__: debug
+    })
+  ],
+  resolve: {
+    root: [JS_PATH, SRC_PATH]
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        include: JS_PATH,
+        exclude: /(node_modules|bower_components)/,
+        loader: 'babel',
+        query: {
+          cacheDirectory: true,
+          presets: ['es2015']
+        }
+      },
+      {
+        test: /\.glsl$/,
+        include: SHADER_PATH,
+        loader: 'webpack-glsl'
+      }
+    ]
+  },
+  debug: debug,
+  devtool: debug ? 'eval-source-map' : 'source-map'
 };


### PR DESCRIPTION
- Removed changelog from README as Releases page on GH shows this
- Correct dev URL in README
- Update HTML template to work with html-webpack-plugin v2
- Added a **DEV** env variable webpack will strip out
- Update html-webpack-plugin; Correct npm run options
- Updated README to reflect command, dependency changes
- Bump version to 1.2.0; Change "npm run dev-server" to "npm run dev"
